### PR TITLE
feat: add list of git commit message types and descriptions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,7 +59,17 @@ Our commit message convention adopts the established [Angular commit convention]
 
 #### Types
 
-Check out [Angular's types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type).
+Use one of the following:
+
+* `build`: Changes that affect the build system or external dependencies
+* `ci`: Changes to CI configuration files or scripts
+* `docs`: Documentation only changes
+* `feat`: A new feature
+* `fix`: A bug fix
+* `perf`: A code change that improves performance
+* `refactor`: A code change that neither fixes a bug nor adds a feature
+* `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing quotes, etc.)
+* `test`: Adding tests or correcting existing tests
 
 #### Scopes
 


### PR DESCRIPTION
Adds list of commit message subject types.  These are almost identical to [Angular's](https://github.com/angular/angular/blob/68a6a07/CONTRIBUTING.md#type).  Some things to consider is whether we want additional types (`chore` and `revert` are ones I've seen used elsewhere, though `chore` was deprecated by Angular in favor of `build` and `ci`).